### PR TITLE
Better support for multi-experiment scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 meticulous/tests/experiments
 experiments
 docsrc/_build/
+__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ meticulous/tests/experiments
 experiments
 docsrc/_build/
 __pycache__/
+temp_files/experiments_meticulous.tests.test_experiment_writer.OutputTestCase.test_args

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "meticulous/tests"]
 	path = meticulous/tests
-	url = https://github.com/AshwinParanjape/meticulous-tests.git
+	url = https://github.com/Whadup/meticulous-tests.git

--- a/README.rst
+++ b/README.rst
@@ -156,6 +156,25 @@ The above code will create a directory structure in your project directory as fo
 * ``STATUS`` file is either RUNNING, SUCCESS, ERROR with the python traceback.
 * ``stdout`` and ``stderr`` files contain the two output streams.
 
+How to record many experiments in a single script?
+-------------------------------
+
+Sometimes we want to run a lot of experiments in a single script, for instance when we tune hyperparameters.
+You can do this conveniently with meticulous.
+
+.. code:: python
+
+  for k in range(1, 10):
+      with Experiment({"k": k}) as exp:
+          print(f"running kmeans with k={k}")
+          kmeans = KMeans(k=k).fit(X)
+          exp.summary({"loss": kmeans._inertia})
+          print(f"Loss was {kmeans._ineartia}")
+
+
+Each experiment starts tracking when it is initialized and stops tracking once the code block is exited. This is also true for the capture of the standard output.
+When an experiment fails with an exception, the error is stored and the execution of the next experiment resumes.
+
 How to get a quick summary?
 ---------------------------
 You can run a utility script ``meticulous`` to list all the experiments in the folder with associated metadata
@@ -166,7 +185,6 @@ You can run a utility script ``meticulous`` to list all the experiments in the f
                                      curexpdir           begin_time   status status_message
     (, sha)              expid
     970d8ad001f5d42a9... 1      experiments/1/  2020-11-02T12:48...  SUCCESS
-
 
 Code snippet
 ------------

--- a/bin/meticulous
+++ b/bin/meticulous
@@ -65,8 +65,8 @@ if __name__ == '__main__':
             final_df = final_df.query(args.filter)
         except Exception as e:
             print("Error in --filter: ", e)
-            print(f"Checkout https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.query.html" + \
-                  f"for an overview on the query syntax. \nAllowed columns: {final_df.columns}")
+            print("Checkout https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.query.html" + \
+                  "for an overview on the query syntax. \nAllowed columns: {}".format(final_df.columns))
     if args.groupby:
         try:
             by = [x.strip() for x in args.groupby.split(",")]

--- a/meticulous/__init__.py
+++ b/meticulous/__init__.py
@@ -1,3 +1,5 @@
 name = "meticulous"
+
 from meticulous.experiment import Experiment
 from meticulous.experiments import Experiments
+from meticulous.repo import REPO, COMMIT

--- a/meticulous/experiment.py
+++ b/meticulous/experiment.py
@@ -279,6 +279,7 @@ class Experiment(object):
         except FileNotFoundError as e:
             print("Creating local .gitignore")
             ignored = False
+        # if the experiment directory is located inside the repo, but not in the .gitignore
         if not ignored and not os.path.relpath(self.experiments_directory, self.repo_directory).startswith(".."):
             print("Adding experiments directory to .gitignore")
             with open(os.path.join(self.repo_directory, '.gitignore'), 'a') as f:

--- a/meticulous/experiment.py
+++ b/meticulous/experiment.py
@@ -135,11 +135,9 @@ class Experiment(object):
             json.dump(self.metadata, f, indent=4)
 
         # Tee stdout and stderr to files as well
-        self.stdout = Tee(sys.stdout, self.open('stdout', 'a'))
-        sys.stdout = self.stdout
-        self.stderr = Tee(sys.stderr, self.open('stderr', 'a'))
+        self.stdout = Tee("stdout", self.open('stdout', 'a'))
+        self.stderr = Tee("stderr", self.open('stderr', 'a'))
 
-        sys.stderr = self.stderr
         self._set_status_file()
 
     @staticmethod

--- a/meticulous/experiment.py
+++ b/meticulous/experiment.py
@@ -273,7 +273,7 @@ class Experiment(object):
         # ignore the experiment directory from git tree if not ignored yet
         try:
             with open(os.path.join(self.repo_directory, '.gitignore'), 'r') as f:
-                ignored = os.path.relpath(self.experiments_directory, self.repo_directory) in [p.strip() for p in f.readlines()]
+                ignored = os.path.relpath(self.experiments_directory, self.repo_directory) in [os.path.normcase(p.strip()) for p in f.readlines()]
         except FileNotFoundError as e:
             print("Creating local .gitignore")
             ignored = False

--- a/meticulous/experiment.py
+++ b/meticulous/experiment.py
@@ -273,7 +273,7 @@ class Experiment(object):
         # ignore the experiment directory from git tree if not ignored yet
         try:
             with open(os.path.join(self.repo_directory, '.gitignore'), 'r') as f:
-                ignored = os.path.relpath(self.experiments_directory, self.repo_directory) in [os.path.normcase(p.strip()) for p in f.readlines()]
+                ignored = os.path.relpath(self.experiments_directory, self.repo_directory) in [os.path.normpath(p.strip()) for p in f.readlines()]
         except FileNotFoundError as e:
             print("Creating local .gitignore")
             ignored = False

--- a/meticulous/experiment.py
+++ b/meticulous/experiment.py
@@ -4,10 +4,12 @@ from git import Repo
 from typing import Dict
 
 from meticulous.utils import Tee, ExitHooks
+from meticulous.repo import REPO, COMMIT
 import atexit
 import traceback
 import logging
 logger = logging.getLogger('meticulous')
+
 
 ch = logging.StreamHandler()
 ch.setLevel(logging.DEBUG)
@@ -65,7 +67,7 @@ class Experiment(object):
         self._set_experiments_directory(experiments_directory)
 
         #Store metadata about the repo
-        commit = self.repo.commit()
+        commit = COMMIT
         self.metadata = {}
         """dict: Metadata stored to metadata.json"""
         self.metadata['githead-sha'] = commit.hexsha
@@ -136,8 +138,8 @@ class Experiment(object):
         self.stdout = Tee(sys.stdout, self.open('stdout', 'a'))
         sys.stdout = self.stdout
         self.stderr = Tee(sys.stderr, self.open('stderr', 'a'))
-        sys.stderr = self.stderr
 
+        sys.stderr = self.stderr
         self._set_status_file()
 
     @staticmethod
@@ -249,7 +251,7 @@ class Experiment(object):
 
     def _set_repo_directory(self):
         """Finds a git repo by searching the project and its parent directories and sets self.repo_directory"""
-        self.repo = Repo(self.project_directory, search_parent_directories=True)
+        self.repo = REPO
         logger.debug("Found git repo at {repo}".format(repo=self.repo))
 
         # Absolute path of the repo
@@ -277,7 +279,7 @@ class Experiment(object):
         except FileNotFoundError as e:
             print("Creating local .gitignore")
             ignored = False
-        if not ignored:
+        if not ignored and not os.path.relpath(self.experiments_directory, self.repo_directory).startswith(".."):
             print("Adding experiments directory to .gitignore")
             with open(os.path.join(self.repo_directory, '.gitignore'), 'a') as f:
                 f.write(os.path.relpath(self.experiments_directory, self.repo_directory)+'\n')
@@ -305,11 +307,42 @@ class Experiment(object):
                                               self.hooks.exc_info['exc_value'],
                                               self.hooks.exc_info['exc_traceback'],
                                               file=f)
+                    traceback.print_exception(self.hooks.exc_info['exc_type'],
+                                              self.hooks.exc_info['exc_value'],
+                                              self.hooks.exc_info['exc_traceback'],
+                                              file=sys.stderr)
                 else:
                     f.write('SUCCESS')
         with self.open('STATUS', 'w') as f:
             f.write('RUNNING')
-        atexit.register(exit_hook)
+        self.atexit_hook = exit_hook
+        atexit.register(self.atexit_hook)
+
+    def finish(self, status="SUCCESS"):
+        self.metadata['end-time'] = datetime.datetime.now().isoformat()
+        with self.open('metadata.json', 'w') as f:
+            json.dump(self.metadata, f, indent=4)
+        with self.open('STATUS', 'w') as f:
+            f.write(status)
+        atexit.unregister(self.atexit_hook)
+        self.stdout.close()
+        self.stderr.close()
+    
+    def __enter__(self):
+        return self
+    def __exit__(self, type, value, tb):
+        if type is not None:
+            self.finish("ERROR\n" + "\n".join(
+                traceback.format_exception(type,
+                                        value,
+                                        tb)
+            ))
+            traceback.print_exception(type,
+                                        value,
+                                        tb,
+                                        file=sys.stderr)
+            return True
+        self.finish()
 
 
 class DirtyRepoException(Exception):

--- a/meticulous/repo.py
+++ b/meticulous/repo.py
@@ -1,0 +1,3 @@
+from git import Repo
+REPO = Repo("", search_parent_directories=True)
+COMMIT = REPO.commit()

--- a/meticulous/utils.py
+++ b/meticulous/utils.py
@@ -35,6 +35,8 @@ class Tee(object):
         :param stdstream: name of the output stream, that gets replaced by the Tee object. Must be either stdout or stderr
         :param fileobject: output file object that needs to be flushed and closed
         """
+        if stdstream not in ["stdout", "stderr"]:
+            raise RuntimeError(f"sys.{stdstream} is not a valid stream to redirect.")
         self.file = fileobject
         self.stdstream_name = stdstream
         self.stdstream = sys.__dict__[stdstream]

--- a/meticulous/utils.py
+++ b/meticulous/utils.py
@@ -32,24 +32,17 @@ class Tee(object):
     """
     def __init__(self, stdstream, fileobject):
         """
-        :param stdstream: output stream, that gets replaced by the Tee object
+        :param stdstream: name of the output stream, that gets replaced by the Tee object. Must be either stdout or stderr
         :param fileobject: output file object that needs to be flushed and closed
         """
         self.file = fileobject
-        self.stdstream = stdstream
-        self.stdout= stdstream is sys.stdout
-        self.stderr= stdstream is sys.stderr
-        if not self.stderr and not self.stdout:
-            sys.stderr.write("WARNING: It seems that you are nesting experiments. This is untested, but you do you!")
-        stdstream = self
+        self.stdstream_name = stdstream
+        self.stdstream = sys.__dict__[stdstream]
+        sys.__dict__[stdstream] = self
 
     def close(self):
         """Close the file and set the stdstream back to the original stdstream"""
-        stdstream = self.stdstream
-        if self.stdout:
-            sys.stdout = self.stdstream
-        if self.stderr:
-            sys.stderr = self.stdstream
+        sys.__dict__[self.stdstream_name] = self.stdstream
         self.file.close()
 
     def __del__(self):

--- a/meticulous/utils.py
+++ b/meticulous/utils.py
@@ -36,7 +36,7 @@ class Tee(object):
         :param fileobject: output file object that needs to be flushed and closed
         """
         if stdstream not in ["stdout", "stderr"]:
-            raise RuntimeError(f"sys.{stdstream} is not a valid stream to redirect.")
+            raise RuntimeError("sys.{} is not a valid stream to redirect.".format(stdstream))
         self.file = fileobject
         self.stdstream_name = stdstream
         self.stdstream = sys.__dict__[stdstream]

--- a/meticulous/utils.py
+++ b/meticulous/utils.py
@@ -37,11 +37,19 @@ class Tee(object):
         """
         self.file = fileobject
         self.stdstream = stdstream
+        self.stdout= stdstream is sys.stdout
+        self.stderr= stdstream is sys.stderr
+        if not self.stderr and not self.stdout:
+            sys.stderr.write("WARNING: It seems that you are nesting experiments. This is untested, but you do you!")
         stdstream = self
 
     def close(self):
         """Close the file and set the stdstream back to the original stdstream"""
         stdstream = self.stdstream
+        if self.stdout:
+            sys.stdout = self.stdstream
+        if self.stderr:
+            sys.stderr = self.stdstream
         self.file.close()
 
     def __del__(self):

--- a/meticulous/utils.py
+++ b/meticulous/utils.py
@@ -41,11 +41,15 @@ class Tee(object):
         self.stdstream_name = stdstream
         self.stdstream = sys.__dict__[stdstream]
         sys.__dict__[stdstream] = self
+        self.closed = False
 
     def close(self):
         """Close the file and set the stdstream back to the original stdstream"""
-        sys.__dict__[self.stdstream_name] = self.stdstream
+        if self.closed:
+            return
         self.file.close()
+        sys.__dict__[self.stdstream_name] = self.stdstream
+        self.closed = True
 
     def __del__(self):
         """Close the file and set the stdstream back to the original stdstream"""


### PR DESCRIPTION
When you run multiple experiments from a single python file, for instance when tuning hyperparameters, some issues arise:

- The git repository status is extracted when each experiment starts. However, in the meantime this status might have changed on disk, while the python process is still using the older codebase. This pull request addresses this by capturing the git status only once at initialization
- The standard output capture is not reset after one experiment finishes. Hence the first experiment captures the output of all other experiments, while the last experiment captures only one. This pull request addresses this by patching the Tee object.
- We need a method for closing experiments. This pull request introduces a ``finish`` method. But more conveniently, it introduces a context manager for running an Experiment:

```python
for k in range(1, 10):
    with Experiment({"k": k}) as exp:
        print(f"running kmeans with k={k}")
        kmeans = KMeans(k=k).fit(X)
        exp.summary({"loss": kmeans._inertia})
        print(f"Loss was {kmeans._ineartia}")
```

Additionally, for convenience we write error messages not only to the `status`-file, but also to `stderr`.