### PR TITLE
Eliminate a pandas normalize_json deprecation warning 

### DIFF
--- a/meticulous/experiments.py
+++ b/meticulous/experiments.py
@@ -5,7 +5,7 @@ import os
 import json
 import traceback
 import pandas as pd
-from pandas.io.json import json_normalize
+from pandas import json_normalize
 
 class ExperimentReader(object):
     """Class to read an experiment folder"""


### PR DESCRIPTION
Use the currently recommended way to normalize a json by pandas.